### PR TITLE
Consume package-based dependencies. Enable default analyze command (e…

### DIFF
--- a/src/SqlSkim.Driver/AnalyzeCommand.cs
+++ b/src/SqlSkim.Driver/AnalyzeCommand.cs
@@ -1,10 +1,31 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.Reflection;
+
+using Microsoft.CodeAnalysis.Sarif.Driver.Sdk;
+using Microsoft.CodeAnalysis.Sql.Rules;
 
 namespace Microsoft.CodeAnalysis.Sql
 {
-    class AnalyzeCommand
+    public class AnalyzeCommand : AnalyzeCommandBase<SqlFileContext, AnalyzeOptions>
     {
+        // No tool-specific function as yet, so only verbose 'analyzing file'
+        // output indicates tool is functioning. 
+        //
+        // e.g.: sqlsqim analyze c:\test\*.sql --verbose
+
+        public override IEnumerable<Assembly> DefaultPlugInAssemblies
+        {
+            get
+            {
+                return new Assembly[] {
+                    typeof(RemoveUnusedVariables).Assembly
+                };
+            }
+        }
+
+        public override string Prerelease { get { return VersionConstants.Prerelease; } }
     }
 }

--- a/src/SqlSkim.Driver/AnalyzeOptions.cs
+++ b/src/SqlSkim.Driver/AnalyzeOptions.cs
@@ -1,10 +1,17 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
+using CommandLine;
+
+using Microsoft.CodeAnalysis.Sarif.Driver.Sdk;
 
 namespace Microsoft.CodeAnalysis.Sql
 {
-    class AnalyzeOptions
+    [Verb("analyze", HelpText = "Analyze one or more SQl files for security and correctness issues.")]
+    public class AnalyzeOptions : AnalyzeOptionsBase
     {
+        // We currently implement no options over the base configuration
     }
 }

--- a/src/SqlSkim.Driver/ExportConfigurationCommand.cs
+++ b/src/SqlSkim.Driver/ExportConfigurationCommand.cs
@@ -5,13 +5,13 @@ using System.Collections.Generic;
 using System.Reflection;
 
 using Microsoft.CodeAnalysis.Sql.Rules;
-using Microsoft.CodeAnalysis.Driver.Sdk;
+using Microsoft.CodeAnalysis.Sarif.Driver.Sdk;
 
 namespace Microsoft.CodeAnalysis.Sql
 {
     internal class ExportConfigurationCommand : ExportConfigurationCommandBase
     {
-        public override IEnumerable<Assembly> DefaultExportAssemblies
+        public override IEnumerable<Assembly> DefaultPlugInAssemblies
         {
             get
             {
@@ -20,5 +20,7 @@ namespace Microsoft.CodeAnalysis.Sql
                 };
             }
         }
+
+        public override string Prerelease { get; }
     }
 }

--- a/src/SqlSkim.Driver/ExportRulesCommand.cs
+++ b/src/SqlSkim.Driver/ExportRulesCommand.cs
@@ -3,14 +3,15 @@
 
 using System.Collections.Generic;
 using System.Reflection;
-using Microsoft.CodeAnalysis.Driver.Sdk;
+
+using Microsoft.CodeAnalysis.Sarif.Driver.Sdk;
 using Microsoft.CodeAnalysis.Sql.Rules;
 
 namespace Microsoft.CodeAnalysis.Sql
 {
     internal class ExportRulesMetadataCommand : ExportRulesMetadataCommandBase
     {
-        public override IEnumerable<Assembly> DefaultExportAssemblies
+        public override IEnumerable<Assembly> DefaultPlugInAssemblies
         {
             get
             {

--- a/src/SqlSkim.Driver/SqlSkim.Driver.csproj
+++ b/src/SqlSkim.Driver/SqlSkim.Driver.csproj
@@ -18,9 +18,13 @@
       <HintPath>..\packages\CommandLineParser.2.0.275-beta\lib\net45\CommandLine.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Driver.Utilities, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\driver-utilities\bld\bin\Driver.Utilities\AnyCPU_Release\Driver.Utilities.dll</HintPath>
+    <Reference Include="Sarif, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Sdk.1.4.10-beta\lib\net40\Sarif.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Sarif.Driver, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Driver.1.0.5-beta\lib\net40\Sarif.Driver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -35,6 +39,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Shared\SharedAssemblyInfo.cs" />
     <Compile Include="SqlSkim.cs" />
+    <Compile Include="SqlSkimCommandBase.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SqlSkim.Parsers\SqlSkim.Parsers.csproj">

--- a/src/SqlSkim.Driver/SqlSkim.cs
+++ b/src/SqlSkim.Driver/SqlSkim.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis.Driver.Sdk;
-
 using CommandLine;
+
+using Microsoft.CodeAnalysis.Sarif.Driver.Sdk;
 
 namespace Microsoft.CodeAnalysis.Sql
 {
@@ -12,9 +12,11 @@ namespace Microsoft.CodeAnalysis.Sql
         internal static int Main(string[] args)
         {
             return Parser.Default.ParseArguments<
+                AnalyzeOptions,
                 ExportConfigurationOptions,
                 ExportRulesMetadataOptions>(args)
                 .MapResult(
+                (AnalyzeOptions analyzeOptions) => new AnalyzeCommand().Run(analyzeOptions),
                 (ExportConfigurationOptions exportConfigurationOptions) => new ExportConfigurationCommand().Run(exportConfigurationOptions),
                 (ExportRulesMetadataOptions exportRulesMetadataOptions) => new ExportRulesMetadataCommand().Run(exportRulesMetadataOptions),
                 errs => 1);

--- a/src/SqlSkim.Driver/SqlSkimCommandBase.cs
+++ b/src/SqlSkim.Driver/SqlSkimCommandBase.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Sql
+{
+    class SqlSkimCommandBase
+    {
+    }
+}

--- a/src/SqlSkim.Driver/packages.config
+++ b/src/SqlSkim.Driver/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="2.0.275-beta" targetFramework="net452" />
+  <package id="Sarif.Driver" version="1.0.5-beta" targetFramework="net452" />
+  <package id="Sarif.Sdk" version="1.4.10-beta" targetFramework="net452" />
   <package id="xunit.runner.console" version="2.1.0" targetFramework="net452" />
 </packages>

--- a/src/SqlSkim.Sdk/SqlFileContext.cs
+++ b/src/SqlSkim.Sdk/SqlFileContext.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.IO;
 
 using Microsoft.CodeAnalysis.Sarif.Driver.Sdk;
 using Microsoft.CodeAnalysis.Sarif.Sdk;
@@ -10,7 +12,16 @@ namespace Microsoft.CodeAnalysis.Sql
 {
     public class SqlFileContext : IAnalysisContext
     {
-        public bool IsValidAnalysisTarget { get; }
+        private static HashSet<string> ValidFileExtensions = new HashSet<string>(
+            new string[] { ".sql" }, StringComparer.OrdinalIgnoreCase);
+    
+        public bool IsValidAnalysisTarget
+        {
+            get
+            {
+                return ValidFileExtensions.Contains(Path.GetExtension(this.TargetUri.LocalPath));
+            }
+        }
 
         public IResultLogger Logger { get; set; }
 


### PR DESCRIPTION
…mits verbose output only on examining any file with a *.sql extension)

@dabrookl @nguerrera @lgolding
