### PR TITLE
Update to latest dependencies and enable simple, single check.

### DIFF
--- a/src/SqlSkim.Driver/AnalyzeCommand.cs
+++ b/src/SqlSkim.Driver/AnalyzeCommand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Sql
             get
             {
                 return new Assembly[] {
-                    typeof(RemoveUnusedVariables).Assembly
+                    typeof(AvoidVariableLengthTypesOfSmallSize).Assembly
                 };
             }
         }

--- a/src/SqlSkim.Driver/ExportConfigurationCommand.cs
+++ b/src/SqlSkim.Driver/ExportConfigurationCommand.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sql
             get
             {
                 return new Assembly[] {
-                    typeof(RemoveUnusedVariables).Assembly
+                    typeof(AvoidVariableLengthTypesOfSmallSize).Assembly
                 };
             }
         }

--- a/src/SqlSkim.Driver/ExportRulesCommand.cs
+++ b/src/SqlSkim.Driver/ExportRulesCommand.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sql
             get
             {
                 return new Assembly[] {
-                    typeof(RemoveUnusedVariables).Assembly
+                    typeof(AvoidVariableLengthTypesOfSmallSize).Assembly
                 };
             }
         }

--- a/src/SqlSkim.Driver/SqlSkim.Driver.csproj
+++ b/src/SqlSkim.Driver/SqlSkim.Driver.csproj
@@ -22,12 +22,12 @@
       <HintPath>..\packages\Microsoft.SqlServer.TransactSql.ScriptDom.12.0.1\lib\net40\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sarif, Version=1.4.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Sdk.1.4.12-beta\lib\net40\Sarif.dll</HintPath>
+    <Reference Include="Sarif, Version=1.4.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Sdk.1.4.13-beta\lib\net40\Sarif.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sarif.Driver, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sarif.Driver.1.0.11-beta\lib\net40\Sarif.Driver.dll</HintPath>
+    <Reference Include="Sarif.Driver, Version=1.0.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Driver.1.0.13-beta\lib\net40\Sarif.Driver.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SqlSkim.Driver/SqlSkim.Driver.csproj.user
+++ b/src/SqlSkim.Driver/SqlSkim.Driver.csproj.user
@@ -4,6 +4,6 @@
     <StartArguments>exportRules d:\repros\sqlskim.rules.xml</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <StartArguments>analyze d:\repros\test.sql</StartArguments>
+    <StartArguments>analyze d:\repros\test.sql  --config default</StartArguments>
   </PropertyGroup>
 </Project>

--- a/src/SqlSkim.Driver/VisitCommand.cs
+++ b/src/SqlSkim.Driver/VisitCommand.cs
@@ -62,7 +62,13 @@ namespace Microsoft.CodeAnalysis.Sql
                 region.StartLine = parseError.Line;
                 region.StartColumn = parseError.Column;
 
-                string message = ConsoleLogger.GetMessageText(context, parseError.Message, ResultKind.Error, region);
+                string message = ConsoleLogger.GetMessageText(
+                    context.TargetUri, 
+                    ErrorDescriptors.ParseError.Id, 
+                    parseError.Message, 
+                    ResultKind.Error, 
+                    region);
+
                 Console.WriteLine(message);
             }
         }

--- a/src/SqlSkim.Driver/packages.config
+++ b/src/SqlSkim.Driver/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="CommandLineParser" version="2.0.275-beta" targetFramework="net452" />
   <package id="Microsoft.SqlServer.TransactSql.ScriptDom" version="12.0.1" targetFramework="net452" />
-  <package id="Sarif.Driver" version="1.0.11-beta" targetFramework="net452" />
-  <package id="Sarif.Sdk" version="1.4.12-beta" targetFramework="net452" />
+  <package id="Sarif.Driver" version="1.0.13-beta" targetFramework="net452" />
+  <package id="Sarif.Sdk" version="1.4.13-beta" targetFramework="net452" />
   <package id="xunit.runner.console" version="2.1.0" targetFramework="net452" />
 </packages>

--- a/src/SqlSkim.Rules/DefaultSqlSkimmer.cs
+++ b/src/SqlSkim.Rules/DefaultSqlSkimmer.cs
@@ -21,11 +21,13 @@ namespace Microsoft.CodeAnalysis.Sql.Rules
             }
         }
 
+        private static Uri s_helpUri = new Uri("https://github.com/microsoft/sqlskim");
+
         public override Uri HelpUri
         {
             get
             {
-                throw new NotImplementedException();
+                return s_helpUri;
             }
         }
     }

--- a/src/SqlSkim.Rules/RuleResources.Designer.cs
+++ b/src/SqlSkim.Rules/RuleResources.Designer.cs
@@ -79,11 +79,20 @@ namespace Microsoft.CodeAnalysis.Sql.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The data type for column &apos;{0}&apos; was defined as {1} of a small size ({2}) which may incur additional storage and performance costs. Declare this data type as a fixed size or ignore the warning in cases performance is not a concern..
+        ///   Looks up a localized string similar to The data type for column &apos;{0}&apos; was defined as type {1} of size ({2}) which may incur additional storage and performance costs over a fixed length type. Declare this column as a fixed size data type or ignore the warning if performance is not a concern..
         /// </summary>
         internal static string SQL2009_Default {
             get {
                 return ResourceManager.GetString("SQL2009_Default", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to size threshold for designating small variable type column definitions.
+        /// </summary>
+        internal static string SQL2009_MissingConfig {
+            get {
+                return ResourceManager.GetString("SQL2009_MissingConfig", resourceCulture);
             }
         }
         

--- a/src/SqlSkim.Rules/RuleResources.resx
+++ b/src/SqlSkim.Rules/RuleResources.resx
@@ -124,7 +124,10 @@
     <value>When you use data types of variable length such as VARCHAR, NVARCHAR, and VARBINARY, you incur an additional storage cost to track the length of the value stored in the data type. In addition, columns of variable length are stored after all columns of fixed length, which can have performance implications. This rule also fires in cases where a type of variable length, such as VARCHAR, is declared with no explicit length. In this case, if specified, the default length is 1. Note that data for types of variable length is physically stored after data for types of fixed length. Therefore, you will cause data movement if you change a column from variable to fixed length in a table that is not empty.</value>
   </data>
   <data name="SQL2009_Default" xml:space="preserve">
-    <value>The data type for column '{0}' was defined as {1} of a small size ({2}) which may incur additional storage and performance costs. Declare this data type as a fixed size or ignore the warning in cases performance is not a concern.</value>
+    <value>The data type for column '{0}' was defined as type {1} of size ({2}) which may incur additional storage and performance costs over a fixed length type. Declare this column as a fixed size data type or ignore the warning if performance is not a concern.</value>
+  </data>
+  <data name="SQL2009_MissingConfig" xml:space="preserve">
+    <value>size threshold for designating small variable type column definitions</value>
   </data>
   <data name="SQL2009_SmallSizeThreshold_Description" xml:space="preserve">
     <value>An inclusive integer value that specifies the upper-bound of what is regarded as a type of small size. A value of 2, for example, configures analysis to regard any type of size 1 or 2 to be regarded as small.</value>

--- a/src/SqlSkim.Rules/SqlSkim.Rules.csproj
+++ b/src/SqlSkim.Rules/SqlSkim.Rules.csproj
@@ -21,13 +21,13 @@
       <HintPath>..\packages\Microsoft.SqlServer.TransactSql.ScriptDom.12.0.1\lib\net40\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sarif, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\sarif-sdk-ms\bld\bin\Sarif.Driver\AnyCPU_Debug\Sarif.dll</HintPath>
+    <Reference Include="Sarif, Version=1.4.12.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Sdk.1.4.12-beta\lib\net40\Sarif.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sarif.Driver, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\sarif-sdk-ms\bld\bin\Sarif.Driver\AnyCPU_Debug\Sarif.Driver.dll</HintPath>
+    <Reference Include="Sarif.Driver, Version=1.0.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Driver.1.0.13-beta\lib\net40\Sarif.Driver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/SqlSkim.Rules/packages.config
+++ b/src/SqlSkim.Rules/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Microsoft.Composition" version="1.0.30" targetFramework="net452" />
   <package id="Microsoft.SqlServer.TransactSql.ScriptDom" version="12.0.1" targetFramework="net452" />
+  <package id="Sarif.Driver" version="1.0.13-beta" targetFramework="net452" />
   <package id="Sarif.Sdk" version="1.4.12-beta" targetFramework="net452" />
   <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />

--- a/src/SqlSkim.Sdk/SqlSkim.Sdk.csproj
+++ b/src/SqlSkim.Sdk/SqlSkim.Sdk.csproj
@@ -22,12 +22,12 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Sarif, Version=1.4.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\sarif-sdk-ms\bld\bin\Sarif.Driver\AnyCPU_Debug\Sarif.dll</HintPath>
+      <HintPath>..\packages\Sarif.Sdk.1.4.12-beta\lib\net40\Sarif.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sarif.Driver, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\sarif-sdk-ms\bld\bin\Sarif.Driver\AnyCPU_Debug\Sarif.Driver.dll</HintPath>
+    <Reference Include="Sarif.Driver, Version=1.0.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Driver.1.0.13-beta\lib\net40\Sarif.Driver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/SqlSkim.Sdk/packages.config
+++ b/src/SqlSkim.Sdk/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.SqlServer.TransactSql.ScriptDom" version="12.0.1" targetFramework="net452" />
+  <package id="Sarif.Driver" version="1.0.13-beta" targetFramework="net452" />
+  <package id="Sarif.Sdk" version="1.4.12-beta" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
@dabrookl @nguerrera @lgolding 

sqlskim is now in a coherent condition, building against latest SARIF Driver/Sdk. we have a single, configurable check enabled. Be sure to pass '--config default' on any test command line in order to configure analysis with default rule options.
